### PR TITLE
add new badge to readme (melpa stable with new tag)

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,8 +1,11 @@
 * foreman-mode
 
 [[http://melpa.org/#/foreman-mode][file:http://melpa.org/packages/foreman-mode-badge.svg]]
+[[http://stable.melpa.org/#/foreman-mode][file:http://stable.melpa.org/packages/foreman-mode-badge.svg]]
+[[https://github.com/zweifisch/foreman-mode/tags][file:https://img.shields.io/github/tag/zweifisch/foreman-mode.svg]]
+[[http://www.gnu.org/licenses/gpl-3.0.html][http://img.shields.io/:license-gpl3-blue.svg]]
 
-Manage Procfile-based applications in Emacs
+/Manage Procfile-based applications in Emacs/
 
 use =foreman-start= to start all applications
 or =foreman= to list all applications specified in =Procfile=


### PR DESCRIPTION
I just add new badges and a tag on latest commit:e90d2b56e83ab914f9ba9e78126bd7a534d5b8fb

I've done this  so that `foreman-mode` is also built on http://stable.melpa.org/#/. :)

(I made it with my package [cask-package-toolset](https://github.com/AdrieanKhisbe/cask-package-toolset.el), if you want I can also help you set up test and ci on travis :) )
