### PR TITLE
Make foreman-mode more friendly to rake tasks

### DIFF
--- a/foreman-mode.el
+++ b/foreman-mode.el
@@ -132,7 +132,7 @@
       (->> (s-lines (buffer-string))
            (-remove 's-blank?)
            (-remove (-partial 's-starts-with? "#"))
-           (-map (-partial 's-split ":"))
+           (-map (-partial 's-split ": "))
            (-map (lambda (task)
                    (let ((key (format "%s:%s" directory (car task))))
                      (if (not (assoc key foreman-tasks))


### PR DESCRIPTION
- When a rake task is specified, like `bundle exec que:work`
  then the s-split for ":" splits the line into 3 parts
  instead of just 2 parts.   This makes the rake task fail
  since the full task name isn't passed over