### PR TITLE
Replace deprecated dash-functional dependency

### DIFF
--- a/foreman-mode.el
+++ b/foreman-mode.el
@@ -7,7 +7,7 @@
 ;; Keywords: foreman
 ;; Version: 0.0.1
 ;; Created: 17th Apr 2015
-;; Package-Requires: ((s "1.9.0") (dash "2.10.0") (dash-functional "1.2.0") (f "0.17.2") (emacs "24"))
+;; Package-Requires: ((s "1.9.0") (dash "2.18.0") (f "0.17.2") (emacs "24"))
 
 ;; This file is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Dash 2.18.0 now subsumes `dash-functional`.

See https://github.com/magnars/dash.el/blob/master/NEWS.md#from-217-to-218